### PR TITLE
Improvement von Visualize Loss, backup the loss list and create a new node without validation

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -392,7 +392,6 @@ class InitFluxLoRATraining:
             "gradient_dtype": (["fp32", "fp16", "bf16"], {"default": "fp32", "tooltip": "the actual dtype training uses"}),
             "save_dtype": (["fp32", "fp16", "bf16", "fp8_e4m3fn", "fp8_e5m2"], {"default": "bf16", "tooltip": "the dtype to save checkpoints as"}),
             "attention_mode": (["sdpa", "xformers", "disabled"], {"default": "sdpa", "tooltip": "memory efficient attention mode"}),
-            "sample_prompts": ("STRING", {"multiline": True, "default": "illustration of a kitten | photograph of a turtle", "tooltip": "validation sample prompts, for multiple prompts, separate by `|`"}),
             },
             "optional": {
                 "additional_args": ("STRING", {"multiline": True, "default": "", "tooltip": "additional args to pass to the training command"}),
@@ -401,6 +400,7 @@ class InitFluxLoRATraining:
                 "clip_l_lr": ("FLOAT", {"default": 0, "min": 0.0, "max": 10.0, "step": 0.000001, "tooltip": "text encoder learning rate"}),
                 "T5_lr": ("FLOAT", {"default": 0, "min": 0.0, "max": 10.0, "step": 0.000001, "tooltip": "text encoder learning rate"}),
                 "block_args": ("ARGS", {"default": "", "tooltip": "limit the blocks used in the LoRA"}),
+                "sample_prompts": ("STRING", {"multiline": True, "default": "illustration of a kitten | photograph of a turtle", "tooltip": "validation sample prompts, for multiple prompts, separate by `|`"}),
                 "gradient_checkpointing": (["enabled", "enabled_with_cpu_offloading", "disabled"], {"default": "enabled", "tooltip": "use gradient checkpointing"}),
             },
             "hidden": {
@@ -413,9 +413,9 @@ class InitFluxLoRATraining:
     FUNCTION = "init_training"
     CATEGORY = "FluxTrainer"
 
-    def init_training(self, flux_models, dataset, optimizer_settings, sample_prompts, output_name, attention_mode, 
+    def init_training(self, flux_models, dataset, optimizer_settings, output_name, attention_mode, 
                       gradient_dtype, save_dtype, split_mode, additional_args=None, resume_args=None, train_text_encoder='disabled', 
-                      block_args=None, gradient_checkpointing="enabled", prompt=None, extra_pnginfo=None, clip_l_lr=0, T5_lr=0, **kwargs,):
+                      block_args=None, sample_prompts="", gradient_checkpointing="enabled", prompt=None, extra_pnginfo=None, clip_l_lr=0, T5_lr=0, **kwargs,):
         mm.soft_empty_cache()
         
         output_dir = os.path.abspath(kwargs.get("output_dir"))
@@ -924,6 +924,64 @@ class FluxTrainAndValidateLoop:
         print("Validating at step:", network_trainer.global_step)
 
     def save(self, network_trainer):
+        ckpt_name = train_util.get_step_ckpt_name(network_trainer.args, "." + network_trainer.args.save_model_as, network_trainer.global_step)
+        network_trainer.optimizer_eval_fn()
+        network_trainer.save_model(ckpt_name, network_trainer.accelerator.unwrap_model(network_trainer.network), network_trainer.global_step, network_trainer.current_epoch.value + 1)
+        network_trainer.optimizer_train_fn()
+        print("Saving at step:", network_trainer.global_step)
+
+class FluxTrainAndSaveLoop:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+            "network_trainer": ("NETWORKTRAINER",),
+            "save_at_steps": ("INT", {"default": 250, "min": 1, "max": 10000, "step": 1, "tooltip": "the step point in training to save"}),
+            "save_state": ("BOOLEAN", {"default": True, "tooltip": "backup the training state of the model"}),
+            },
+        }
+
+    RETURN_TYPES = ("NETWORKTRAINER", "INT",)
+    RETURN_NAMES = ("network_trainer", "steps",)
+    FUNCTION = "train"
+    CATEGORY = "FluxTrainer"
+
+    def train(self, network_trainer, save_at_steps, save_state):
+        with torch.inference_mode(False):
+            training_loop = network_trainer["training_loop"]
+            network_trainer = network_trainer["network_trainer"]
+
+            target_global_step = network_trainer.args.max_train_steps
+            comfy_pbar = comfy.utils.ProgressBar(target_global_step)
+            network_trainer.comfy_pbar = comfy_pbar
+
+            network_trainer.optimizer_train_fn()
+
+            while network_trainer.global_step < target_global_step:
+                next_save_step = ((network_trainer.global_step // save_at_steps) + 1) * save_at_steps
+
+                # set current epoch to start epoch on resume
+                if network_trainer.current_epoch.value < network_trainer.epoch_to_start:
+                    network_trainer.current_epoch.value = network_trainer.epoch_to_start
+                steps_done = training_loop(
+                    break_at_steps=next_save_step,
+                    epoch=network_trainer.current_epoch.value,
+                )
+
+                # Check if we need to save
+                if network_trainer.global_step % save_at_steps == 0:
+                    self.save(network_trainer, save_state)
+
+                # Also break if the global steps have reached the max train steps
+                if network_trainer.global_step >= network_trainer.args.max_train_steps:
+                    break
+
+            trainer = {
+                "network_trainer": network_trainer,
+                "training_loop": training_loop,
+            }
+        return (trainer, network_trainer.global_step)
+
+    def save(self, network_trainer, save_state):
         ckpt_name = train_util.get_step_ckpt_name(network_trainer.args, "." + network_trainer.args.save_model_as, network_trainer.global_step)
         network_trainer.optimizer_eval_fn()
         network_trainer.loss_recorder.addsavepoint(network_trainer.global_step)
@@ -1715,6 +1773,7 @@ NODE_CLASS_MAPPINGS = {
     "FluxTrainBlockSelect": FluxTrainBlockSelect,
     "TrainDatasetRegularization": TrainDatasetRegularization,
     "FluxTrainAndValidateLoop": FluxTrainAndValidateLoop,
+    "FluxTrainAndSaveLoop": FluxTrainAndSaveLoop,
     "OptimizerConfigProdigyPlusScheduleFree": OptimizerConfigProdigyPlusScheduleFree,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -1740,5 +1799,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "FluxTrainBlockSelect": "Flux Train Block Select",
     "TrainDatasetRegularization": "Train Dataset Regularization",
     "FluxTrainAndValidateLoop": "Flux Train And Validate Loop",
+    "FluxTrainAndSaveLoop": "Flux Train And Save Loop",
     "OptimizerConfigProdigyPlusScheduleFree": "Optimizer Config ProdigyPlusScheduleFree",
 }

--- a/train_network.py
+++ b/train_network.py
@@ -1098,7 +1098,7 @@ class NetworkTrainer:
         self.remove_model = remove_model
         self.comfy_pbar = None
         
-        progress_bar = tqdm(range(args.max_train_steps - initial_step), smoothing=0, disable=False, desc="steps")
+        progress_bar = tqdm(range(args.max_train_steps - self.global_step), smoothing=0, disable=False, desc="steps")
         
         def training_loop(break_at_steps, epoch):
             steps_done = 0

--- a/train_network.py
+++ b/train_network.py
@@ -1006,6 +1006,17 @@ class NetworkTrainer:
         )
 
         self.loss_recorder = train_util.LossRecorder()
+        if args.resume:
+            lossfile = os.path.join(args.resume, "losslist.json")
+            if os.path.isfile(lossfile):
+                with open(lossfile, 'r') as f:
+                    self.loss_recorder.global_loss_list = json.load(f)
+                    accelerator.print("losslist loaded")
+            savepointfile = os.path.join(args.resume, "savepoints.json")
+            if os.path.isfile(savepointfile):
+                with open(savepointfile, 'r') as f:
+                    self.loss_recorder.savepoints = json.load(f)
+                    accelerator.print("savepointlist loaded")
         del train_dataset_group
 
         pbar.update(1)


### PR DESCRIPTION
Within this PR are three commits:

- https://github.com/kijai/ComfyUI-FluxTrainer/commit/1cc2554a13a5dc4240c6f6abaa119bda1d294429 improves the Visualize Loss function. If you save states, the loss is not saved too. So when the occasional crashes happen, you lose the loss plot which is quite useful in determining which epoch to pick. So I saved the loss list to the states folder. Then, the shift because of the running average in the loss plot was not considered, the plot is now shifted for the window_size to the right. I also saved a list of savepoints with the states and marked these savepoints with vertical lines in the plot that you can see where exactly your savepoints are.
- https://github.com/kijai/ComfyUI-FluxTrainer/commit/51aa87ff9d88557a80b31e93ca4333d35bcb342b simply changes the epoch in the progress bar to the total number if you resume from a saved state.
- https://github.com/kijai/ComfyUI-FluxTrainer/commit/785bc6d346a122d46cd11791b313a6fedde795a4 adds a new loop node without validation. Validation gets an OOM when training with 16GB VRAM. So this node is a copy of the normal loop node, without validation. I also made the prompt input to the init node optional to create a cleaner workflow. 