### PR TITLE
Fix FluxTrainAndValidateLoop.validate

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -980,15 +980,9 @@ class FluxTrainAndValidateLoop:
         return (trainer, network_trainer.global_step)
 
     def validate(self, network_trainer, validation_settings=None):
-        params = (
-            network_trainer.accelerator, 
-            network_trainer.args, 
+        params = ( 
             network_trainer.current_epoch.value, 
             network_trainer.global_step,
-            network_trainer.unet,
-            network_trainer.vae,
-            network_trainer.text_encoder,
-            network_trainer.sample_prompts_te_outputs,
             validation_settings
         )
         network_trainer.optimizer_eval_fn()


### PR DESCRIPTION
It fixes wrong arguments count passed to sample_images in FluxTrainAndValidateLoop.validate.